### PR TITLE
Prevent flash content when loading page

### DIFF
--- a/website/src/Pages/Docs.fs
+++ b/website/src/Pages/Docs.fs
@@ -13,9 +13,9 @@ let view (page: string) =
     Shoelace.SlInclude [
       Attr.src $"/dist/docs/{page}.html"
       Attr.custom ("allow-scripts", "true")
-      Html.p [
-        text
+      on "sl-error" (fun _ ->
+        Browser.Dom.document.querySelector(".doc-page").textContent <-
           "We were not able to find that page, are you sure the url address is correct?"
-      ]
+      ) []
     ]
   ]


### PR DESCRIPTION
Hi @AngelMunoz, thanks a lot for this great project! :clap: :clap: :clap:

When browsing the documentation I noticed a small flash when loading the page. By checking the code and Shoelace docs, it seems we can avoid it by not showing the error message by default (so it's displayed briefly when the content is loading) but only in the case the `sl-error` event is triggered.